### PR TITLE
Don't call `fireChannelActive` more than once

### DIFF
--- a/core/src/main/java/io/netty/contrib/security/core/standards/StandardNetworkHandler.java
+++ b/core/src/main/java/io/netty/contrib/security/core/standards/StandardNetworkHandler.java
@@ -70,7 +70,6 @@ public class StandardNetworkHandler implements ChannelHandler {
         } else {
             logger.error("Unknown Channel Type: " + ctx.channel().getClass().getSimpleName());
         }
-        ctx.fireChannelActive();
     }
 
     @Override


### PR DESCRIPTION
We can `fireChannelActive` more than once. Once in `channelActive` and once `channelActive0`.